### PR TITLE
Bug Fix + Escriptize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 all:
-	@./rebar compile
+	@./rebar compile escriptize
 
 test: force
 	@./rebar eunit

--- a/src/grapherl.erl
+++ b/src/grapherl.erl
@@ -32,6 +32,7 @@
 -copyright("Erlang Solutions Ltd.").
 -author("Adam Lindberg <eproxus@gmail.com>").
 
+-export([main/1]).
 -export([applications/2]).
 -export([applications/3]).
 -export([modules/2]).
@@ -40,6 +41,33 @@
 %%==============================================================================
 %% API Functions
 %%==============================================================================
+
+%% @hidden
+main(["-applications", Target]) ->
+    main(["-applications", "ebin", Target]);
+main(["-applications", Dir, Target]) ->
+    run(applications, [Dir, Target]);
+main(["-modules", Target]) ->
+    main(["-modules", "ebin", Target]);
+main(["-modules", Dir, Target]) ->
+    run(modules, [Dir, Target, [no_ebin]]);
+main(_) ->
+    io:format(
+      "Usage:~n"
+      " grapherl -applications Target~n"
+      " grapherl -applications Dir Target~n"
+      " grapherl -modules Target~n"
+      " grapherl -modules Dir Target~n"
+     ),
+    halt(1).
+
+run(Fun, Args) ->
+    case apply(?MODULE, Fun, Args) of
+	ok -> io:format("Ok~n");
+	{error, Error} ->
+	    io:format("Error:~n~p~n", [Error]),
+	    halt(1)
+    end.
 
 %% @equiv applications(Dir, Target, [{type, png}])
 applications(Dir, Target) ->


### PR DESCRIPTION
Hey Adam,

Only two commits here of are of interest, but I can't seem to select only those two for some reason. They are:

`Wrap module names in quotes` - which does as the name implies so that module names with dashes in them can be handled.

`Add basic escriptize support` - takes advantage of rebar's escriptize feature to build a standalone grapherl command line tool.

Cheers,

Andrew
