### PR TITLE
Fix get_type/2 by accepting list as type

### DIFF
--- a/src/grapherl.erl
+++ b/src/grapherl.erl
@@ -196,7 +196,8 @@ stop_xref(Ref) ->
 get_type(Options, Target) ->
     case proplists:get_value(type, Options) of
         undefined -> type_from_filename(Target);
-        Type -> atom_to_list(Type)
+        Type when is_atom(Type) -> atom_to_list(Type);
+        Type -> Type
     end.
 
 type_from_filename(Filename) ->


### PR DESCRIPTION
when executable command takes arguments, type is list and it causes following error:

localhost [/home/hirotnk/repo/github/grapherl%] ./grapherl -m -t png "/usr/lib64/erlang/lib/thrift-0.8.0/ebin" thrift.png                                                                                                                          [1:39 13-04-06]
escript: exception error: bad argument
  in function  atom_to_list/1
     called as atom_to_list("png")
  in call from grapherl:get_type/2 (src/grapherl.erl, line 199)
  in call from grapherl:create/3 (src/grapherl.erl, line 216)
  in call from grapherl:modules/3 (src/grapherl.erl, line 160)
  in call from grapherl:run/2 (src/grapherl.erl, line 88)
  in call from escript:run/2 (escript.erl, line 741)
  in call from escript:start/1 (escript.erl, line 277)
  in call from init:start_it/1
